### PR TITLE
How do I add Python 3.7 in allow_failures mode?

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,11 +67,11 @@ environment:
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7.1"
+      PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.1"
+      PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
 
     # Major and minor releases (i.e x.0.0 and x.y.0) prior to 3.3.0 use

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
 
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
-    # See: http://www.appveyor.com/docs/installed-software#python
+    # See: https://www.appveyor.com/docs/windows-images-software/#python
 
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x" # currently 2.7.9
@@ -64,6 +64,14 @@ environment:
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.1"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.1"
       PYTHON_ARCH: "64"
 
     # Major and minor releases (i.e x.0.0 and x.y.0) prior to 3.3.0 use


### PR DESCRIPTION
Adding Python 3.7 seems easy but not the __allow_failures__ mode.